### PR TITLE
fix: Emergency production fixes for events page

### DIFF
--- a/netlify/edge-functions/_shared/auth.js
+++ b/netlify/edge-functions/_shared/auth.js
@@ -46,15 +46,21 @@ function constantTimeEqual(a, b) {
 export function checkAuth(request) {
   // Get origin from request headers
   const origin = request.headers.get('Origin') || request.headers.get('Referer');
-  const allowedOrigin = Deno.env.get('ALLOWED_ORIGIN') || 'https://siege-clan.com';
+  const allowedOrigin = Deno.env.get('ALLOWED_ORIGIN') || 'https://www.siege-clan.com';
 
   // Allow same-origin requests without API key
   if (origin) {
     try {
       const originUrl = new URL(origin);
       const allowedUrl = new URL(allowedOrigin);
-      // Exact hostname match (includes port if specified)
-      if (originUrl.hostname === allowedUrl.hostname &&
+
+      // Normalize hostnames by removing www. prefix for comparison
+      const normalizeHostname = (hostname) => hostname.replace(/^www\./, '');
+      const originHostname = normalizeHostname(originUrl.hostname);
+      const allowedHostname = normalizeHostname(allowedUrl.hostname);
+
+      // Match normalized hostnames (allows both www and non-www)
+      if (originHostname === allowedHostname &&
           (originUrl.port || (originUrl.protocol === 'https:' ? '443' : '80')) ===
           (allowedUrl.port || (allowedUrl.protocol === 'https:' ? '443' : '80'))) {
         return { authorized: true };

--- a/src/components/EventsTable.jsx
+++ b/src/components/EventsTable.jsx
@@ -17,7 +17,7 @@ export default function EventsTable({
 
   // Combine local events with WOM competitions
   const combinedEvents = useMemo(() => {
-    if (!includeWomCompetitions || !competitions) return events || [];
+    if (!includeWomCompetitions || !competitions || !Array.isArray(competitions)) return events || [];
 
     // Create a set of WOM IDs that are already in the database
     const existingWomIds = new Set();


### PR DESCRIPTION
- Fix auth origin mismatch: update default ALLOWED_ORIGIN to include www
- Add hostname normalization to allow both www and non-www versions
- Fix EventsTable crash: add Array.isArray check for competitions data

Resolves 401 errors on all API endpoints and prevents EventsTable from crashing when API returns error responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)