### PR TITLE
feat: Hide members with left_date from all member lists

### DIFF
--- a/netlify/edge-functions/members.js
+++ b/netlify/edge-functions/members.js
@@ -41,6 +41,7 @@ export default async (request, _context) => {
     const { data, error } = await supabase
       .from('members')
       .select('*') // Fetch all columns from the members table
+      .is('left_date', null) // Filter out members who have left
       .order('name'); // Order by name
     
     if (error) throw error;

--- a/netlify/functions/anniversaries.js
+++ b/netlify/functions/anniversaries.js
@@ -28,11 +28,13 @@ async function sendAnniversaries() {
       const { data: feb28Members, error: error1 } = await supabase
         .from('members')
         .select('wom_id, name, wom_name, join_date')
+        .is('left_date', null)
         .filter('join_date::text', 'ilike', '%-02-28');
 
       const { data: feb29Members, error: error2 } = await supabase
         .from('members')
         .select('wom_id, name, wom_name, join_date')
+        .is('left_date', null)
         .filter('join_date::text', 'ilike', '%-02-29');
 
       if (error1 || error2) {
@@ -46,6 +48,7 @@ async function sendAnniversaries() {
       const { data: queryMembers, error } = await supabase
         .from('members')
         .select('wom_id, name, wom_name, join_date')
+        .is('left_date', null)
         .filter('join_date::text', 'ilike', `%-${monthDay}`);
 
       if (error) {

--- a/netlify/functions/members.js
+++ b/netlify/functions/members.js
@@ -33,7 +33,8 @@ exports.handler = async function(event, context) {
     // Fetch data from Supabase
     const { data, error } = await supabase
       .from('members')
-      .select('*');
+      .select('*')
+      .is('left_date', null);
 
     if (error) throw error;
 

--- a/src/__tests__/useMembers.test.jsx
+++ b/src/__tests__/useMembers.test.jsx
@@ -5,9 +5,11 @@ vi.mock('../utils/supabaseClient', () => ({
   getAdminSupabaseClient: () => ({
     from: () => ({
       select: () => ({
-        order: () => Promise.resolve({
-          data: [{ id: 1, name: 'Test Member' }],
-          error: null,
+        is: () => ({
+          order: () => Promise.resolve({
+            data: [{ id: 1, name: 'Test Member' }],
+            error: null,
+          }),
         }),
       }),
     }),

--- a/src/components/MemberTable.jsx
+++ b/src/components/MemberTable.jsx
@@ -244,8 +244,8 @@ export default function MemberTable({ filteredMembers = null }) {
   const sortedMembers = useMemo(() => {
     if (!enhancedMembers) return [];
 
-    // Filter out hidden members
-    const visibleMembers = enhancedMembers.filter((member) => !member.hidden);
+    // Filter out hidden members and members who have left
+    const visibleMembers = enhancedMembers.filter((member) => !member.hidden && !member.left_date);
 
     // Then sort the visible members
     return [...visibleMembers].sort((a, b) => {

--- a/src/hooks/useMembers.js
+++ b/src/hooks/useMembers.js
@@ -43,6 +43,7 @@ export function useMembers() {
       const { data, error: fetchError } = await client
         .from('members')
         .select('*')
+        .is('left_date', null)
         .order('name');
       
       if (fetchError) {


### PR DESCRIPTION
This change ensures that members who have left the clan (left_date is not null) are filtered out from all member lists throughout the application.

Changes made:
- Updated useMembers hook to filter out members with left_date
- Updated edge function (netlify/edge-functions/members.js) to filter out members with left_date
- Updated netlify function (netlify/functions/members.js) to filter out members with left_date
- Updated anniversaries function to exclude former members from anniversary notifications
- Added client-side filtering in MemberTable component as an additional safety layer

This provides a comprehensive solution with both server-side and client-side filtering to ensure members who have left are not displayed in any member lists.