### PR TITLE
Trigger WOM group update-all before each sync

### DIFF
--- a/.github/workflows/hourly-clan-sync.yml
+++ b/.github/workflows/hourly-clan-sync.yml
@@ -28,6 +28,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           WOM_API_KEY: ${{ secrets.WOM_API_KEY }}
           WOM_GROUP_ID: ${{ vars.WOM_GROUP_ID || secrets.WOM_GROUP_ID }}
+          WOM_VERIFICATION_CODE: ${{ secrets.WOM_VERIFICATION_CODE }}
           
       - name: Run WOM Events Sync
         if: ${{ github.event.inputs.job_to_run == 'wom-events' || github.event.inputs.job_to_run == 'all' || github.event_name == 'schedule' }}

--- a/.github/workflows/manual-clan-sync.yml
+++ b/.github/workflows/manual-clan-sync.yml
@@ -46,6 +46,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           WOM_API_KEY: ${{ secrets.WOM_API_KEY }}
           WOM_GROUP_ID: ${{ vars.WOM_GROUP_ID || secrets.WOM_GROUP_ID }}
+          WOM_VERIFICATION_CODE: ${{ secrets.WOM_VERIFICATION_CODE }}
           
       - name: Run WOM Events Sync
         if: ${{ github.event.inputs.job_to_run == 'wom-events' || github.event.inputs.job_to_run == 'all' || github.event_name == 'schedule' }}

--- a/scripts/sync-tasks/sync-wom.cjs
+++ b/scripts/sync-tasks/sync-wom.cjs
@@ -11,6 +11,7 @@ const supabase = createClient(
 // WOM API configuration
 const WOM_API_KEY = process.env.WOM_API_KEY || process.env.REACT_APP_WOM_API_KEY;
 const WOM_GROUP_ID = process.env.WOM_GROUP_ID || process.env.REACT_APP_WOM_GROUP_ID;
+const WOM_VERIFICATION_CODE = process.env.WOM_VERIFICATION_CODE;
 const WOM_API_BASE = 'https://api.wiseoldman.net/v2';
 
 // Helper function to add delay with exponential backoff
@@ -62,6 +63,40 @@ async function fetchWithRetry(url, options = {}, retries = 3, initialBackoff = 2
   throw lastError || new Error('Request failed after multiple retries');
 }
 
+// Ask WOM to refresh its cached stats for any group member whose data is
+// older than 24h. Without this, our sync only ever pulls whatever WOM
+// happens to have cached — which drifts as OSRS hiscores change.
+// Runs before the read so the refreshed stats are available by the next run.
+// Best-effort: logs and returns on missing code or API error.
+async function triggerGroupUpdateAll() {
+  if (!WOM_VERIFICATION_CODE) {
+    console.log('Skipping group update-all: WOM_VERIFICATION_CODE not set.');
+    return;
+  }
+  try {
+    const response = await fetch(`${WOM_API_BASE}/groups/${WOM_GROUP_ID}/update-all`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': WOM_API_KEY,
+      },
+      body: JSON.stringify({ verificationCode: WOM_VERIFICATION_CODE }),
+    });
+    const body = await response.json().catch(() => ({}));
+    const message = body.message || '(no message)';
+    // WOM returns 400 with a benign "no outdated members" message when
+    // everyone's stats are already fresh. Not an error, just a no-op.
+    const noop = response.status === 400 && /no outdated members/i.test(message);
+    if (response.ok || noop) {
+      console.log(`WOM group update-all: ${message}`);
+    } else {
+      console.log(`WOM group update-all failed (${response.status}): ${message}`);
+    }
+  } catch (err) {
+    console.log(`WOM group update-all threw: ${err.message}`);
+  }
+}
+
 // Main function to sync WOM members
 async function syncWomMembers() {
   try {
@@ -73,6 +108,7 @@ async function syncWomMembers() {
     console.log(`- SUPABASE_SERVICE_ROLE_KEY: ${process.env.SUPABASE_SERVICE_ROLE_KEY ? 'Set ✓' : 'Missing ❌'}`);
     console.log(`- WOM_API_KEY: ${WOM_API_KEY ? 'Set ✓' : 'Missing ❌'}`);
     console.log(`- WOM_GROUP_ID: ${WOM_GROUP_ID ? 'Set ✓' : 'Missing ❌'}`);
+    console.log(`- WOM_VERIFICATION_CODE: ${WOM_VERIFICATION_CODE ? 'Set ✓' : 'Missing (update-all will be skipped)'}`);
     
     // Check if we have all required environment variables
     if (!WOM_GROUP_ID) {
@@ -80,7 +116,10 @@ async function syncWomMembers() {
     }
     
     console.log(`Using WOM Group ID: ${WOM_GROUP_ID}`);
-    
+
+    // Trigger a refresh of WOM's own cache before we read from it.
+    await triggerGroupUpdateAll();
+
     // Fetch current WOM group members with proper API key authentication
     console.log("Fetching current WOM group members...");
     const groupData = await fetchWithRetry(`${WOM_API_BASE}/groups/${WOM_GROUP_ID}?includeMemberships=true`);


### PR DESCRIPTION
## Why

\`sync-wom.cjs\` only reads whatever stats WOM has cached. For existing members it never asks WOM to refresh from OSRS hiscores — only new members get a \`POST /players/:name/update\` call. Over time, WOM's cache drifts out of date with OSRS, and so does our copy.

This just happened: clicking "Update All" on wiseoldman.net showed 179 of 193 members were outdated, meaning both WOM and our DB had stale stats for most of the clan.

## What

- \`scripts/sync-tasks/sync-wom.cjs\`: added \`triggerGroupUpdateAll()\` that runs at the start of every sync. It \`POST\`s to \`/groups/:id/update-all\` with a verification code in the body — WOM then queues every member last updated >24h ago to re-fetch from OSRS hiscores. By the next scheduled run, their stats will be fresh.
- Best-effort semantics: missing \`WOM_VERIFICATION_CODE\` logs "Skipping…" and continues. A 400 with "no outdated members" logs informationally, not as an error.
- \`hourly-clan-sync.yml\` + \`manual-clan-sync.yml\`: wired \`WOM_VERIFICATION_CODE\` through the env. \`daily-clan-sync.yml\` doesn't run the WOM sync, left alone.

## Activation

No new setup needed. The \`WOM_VERIFICATION_CODE\` repo secret already exists (has for a year — it just wasn't wired to any workflow). This PR connects it. Merges immediately into the next hourly run.

## Test plan

- [x] Ran locally against staging without the code in \`.env\`: \`Skipping group update-all: WOM_VERIFICATION_CODE not set.\` logs, sync continues.
- [x] Ran locally against staging with the code in \`.env\`: WOM accepts the auth, endpoint reached, responded \`"This group has no outdated members (updated over 24h ago)."\` (expected right after a manual Update All). Response is logged as an informational line, not as a failure. Sync continues.
- [ ] After merge: first hourly run should log \`WOM group update-all: N outdated … players are being updated.\` if any members are stale, then pick up fresh stats on the run after that.
- [x] No new test regressions (full \`npm test -- --run\` still 8 failing / 221 passing / 1 skipped, matching the known baseline).